### PR TITLE
removed unnecessary use statement

### DIFF
--- a/zome/zomes/profiles/src/lib.rs
+++ b/zome/zomes/profiles/src/lib.rs
@@ -7,8 +7,6 @@ mod utils;
 pub use profile::*;
 pub use utils::*;
 
-use profile::AgentProfile;
-
 pub fn err(reason: &str) -> WasmError {
     WasmError::Guest(String::from(reason))
 }


### PR DESCRIPTION
sorry, I mistakenly added the use statement for AgentProfile thus making the struct private again when used from outside.
removed it and now it works