### PR TITLE
added hoistTooltip property to agent-avatar

### DIFF
--- a/ui/demo/index.html
+++ b/ui/demo/index.html
@@ -75,7 +75,14 @@
               <profile-prompt>
                 <my-profile style="height: 800px; width: 800px;"></my-profile>
                 <search-agent include-myself></search-agent>
-                <agent-avatar .agentPubKey=${this.store.myAgentPubKey}>
+                <div style="overflow: hidden; height: 70px; border: 1px solid black;">
+                  .hoistTooltip=false
+                  <agent-avatar .agentPubKey=${this.store.myAgentPubKey}>
+                </div>
+                <div style="overflow: hidden; height: 70px; border: 1px solid black;">
+                  .hoistTooltip=true
+                  <agent-avatar .agentPubKey=${this.store.myAgentPubKey} hoistTooltip>
+                </div>
                   <div
                     style="background-color: lightgreen; width: 12px; height: 12px; border-radius: 50%"
                     slot="badge"

--- a/ui/src/elements/agent-avatar.ts
+++ b/ui/src/elements/agent-avatar.ts
@@ -39,6 +39,9 @@ export class AgentAvatar extends ScopedElementsMixin(LitElement) {
   @property({ type: Object })
   store!: ProfilesStore;
 
+  @property({ type: Boolean })
+  hoistTooltip: boolean = false;
+
   _profileTask = new TaskSubscriber(
     this,
     () => this.store.fetchAgentProfile(this.agentPubKey),
@@ -47,7 +50,7 @@ export class AgentAvatar extends ScopedElementsMixin(LitElement) {
 
   renderIdenticon() {
     return html` <div style="position: relative">
-      <holo-identicon .hash=${this.agentPubKey} .size=${this.size}>
+      <holo-identicon .hash=${this.agentPubKey} .size=${this.size} .hoistTooltip=${this.hoistTooltip}>
       </holo-identicon>
       <div class="badge"><slot name="badge"></slot></div>
     </div>`;


### PR DESCRIPTION
Passing on the `hoist` property of the `<sl-tooltip>` element to `<agent-avatar>`.

Demo is adapted accordingly:

![image](https://user-images.githubusercontent.com/36768177/175096317-e3f15750-49a3-457f-abf2-df21532dd7e4.png)
![image](https://user-images.githubusercontent.com/36768177/175096346-ae16459a-cd45-49c6-ba90-fa362b01ca76.png)
