### PR TITLE
fixed width of profile-list list-elements to cover 100% of the width

### DIFF
--- a/ui/demo/index.html
+++ b/ui/demo/index.html
@@ -26,6 +26,7 @@
         AgentAvatar,
         ProfilesStore,
         MyProfile,
+        ListProfiles,
         ProfilesContext,
         SearchAgent,
         ProfilesService
@@ -81,6 +82,10 @@
                     slot="badge"
                   ></div>
                 </agent-avatar>
+                <div style="width: 200px; margin-left: 20px; display: flex; flex-direction: column;">
+                  <div>All profiles:</div>
+                  <list-profiles style="width: 170px; height: 300px; border: 1px solid gray; overflow-y: auto;"></list-profiles>
+                </div>
               </profile-prompt>
             </profiles-context>
           `;
@@ -94,6 +99,7 @@
             'profiles-context': ProfilesContext,
             'agent-avatar': AgentAvatar,
             'sl-badge': SlBadge,
+            'list-profiles': ListProfiles,
           };
         }
       }

--- a/ui/src/elements/list-profiles.ts
+++ b/ui/src/elements/list-profiles.ts
@@ -71,7 +71,7 @@ export class ListProfiles extends ScopedElementsMixin(LitElement) {
 
     return html`
       <mwc-list
-        style="min-width: 80px;"
+        style="min-width: 80px; width: 100%;"
         @selected=${(e: CustomEvent) => this.fireAgentSelected(e.detail.index)}
       >
         ${Object.entries(profiles).map(

--- a/ui/src/elements/profile-prompt.ts
+++ b/ui/src/elements/profile-prompt.ts
@@ -47,7 +47,7 @@ export class ProfilePrompt extends ScopedElementsMixin(LitElement) {
     return html`
     <div
       class="column"
-      style="align-items: center; justify-content: center; flex: 1;"
+      style="align-items: center; flex: 1;"
     >
       <div class="column" style="align-items: center;">
         <slot name="hero"></slot>


### PR DESCRIPTION
@guillemcordoba please check. Supposed to improve the UI of the profile-list element.

Before:
![image](https://user-images.githubusercontent.com/36768177/175886964-3a0b5a5d-a08b-41aa-98a0-9a2c00db5852.png)

After:

![image](https://user-images.githubusercontent.com/36768177/175886995-17a3c9e9-2f06-44b9-abef-d612586e86d7.png)
