### PR TITLE
docs(zome-guide): fix DNA yaml indentation

### DIFF
--- a/docs/guides/setting-up/adding-the-zome.md
+++ b/docs/guides/setting-up/adding-the-zome.md
@@ -53,8 +53,8 @@ coordinator:
   zomes: 
     - name: profiles
       bundled: ../../target/wasm32-unknown-unknown/release/profiles.wasm
-        dependencies:
-          - name: profiles_integrity
+      dependencies:
+        - name: profiles_integrity
 ```
 
 Be careful about the bundled path `../../` , change that to whatever path matches your target folder.


### PR DESCRIPTION
Hi @guillemcordoba, the indentation needs to be adapted for this to be copy-pastable =)