### PR TITLE
Split types crate into coordinator types and integrity types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,9 +1705,18 @@ name = "hc_zome_profiles_coordinator"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "hc_zome_profiles_coordinator_types",
  "hc_zome_profiles_integrity",
- "hc_zome_profiles_types",
+ "hc_zome_profiles_integrity_types",
  "hdk",
+ "serde",
+]
+
+[[package]]
+name = "hc_zome_profiles_coordinator_types"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
  "serde",
 ]
 
@@ -1716,13 +1725,13 @@ name = "hc_zome_profiles_integrity"
 version = "0.0.1"
 dependencies = [
  "derive_more",
- "hc_zome_profiles_types",
+ "hc_zome_profiles_integrity_types",
  "hdi",
  "serde",
 ]
 
 [[package]]
-name = "hc_zome_profiles_types"
+name = "hc_zome_profiles_integrity_types"
 version = "0.0.1"
 dependencies = [
  "derive_more",
@@ -5264,7 +5273,8 @@ version = "0.0.1"
 dependencies = [
  "fixt 0.0.11",
  "futures",
- "hc_zome_profiles_types",
+ "hc_zome_profiles_coordinator_types",
+ "hc_zome_profiles_integrity_types",
  "hdk",
  "holochain",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [workspace]
 members = [
+  "crates/types/*",
   "crates/*",
   "tests",
 ]
+exclude = [ "crates/types" ]
 resolver = "2"
 
 [profile.dev]

--- a/crates/coordinator/Cargo.toml
+++ b/crates/coordinator/Cargo.toml
@@ -17,6 +17,7 @@ name = "hc_zome_profiles_coordinator"
 derive_more = "0"
 serde = "1"
 
-hc_zome_profiles_types = {path = "../types"}
+hc_zome_profiles_coordinator_types = {path = "../types/coordinator_types"}
+hc_zome_profiles_integrity_types = {path = "../types/integrity_types"}
 hc_zome_profiles_integrity = {path = "../integrity"}
 hdk = "0.0.142"

--- a/crates/coordinator/src/handlers.rs
+++ b/crates/coordinator/src/handlers.rs
@@ -1,5 +1,5 @@
+use hc_zome_profiles_integrity_types::*;
 use hc_zome_profiles_integrity::*;
-use hc_zome_profiles_types::*;
 use hdk::{hash_path::path::TypedPath, prelude::*};
 
 pub fn create_profile(profile: Profile) -> ExternResult<Record> {

--- a/crates/coordinator/src/lib.rs
+++ b/crates/coordinator/src/lib.rs
@@ -1,17 +1,18 @@
 //! ## hc_zome_profiles
-//! 
+//!
 //! Profiles zome for any Holochain app.
-//! 
+//!
 //! If you need to manage profiles (nickname, name, avatar, age and other useful personal information)
 //! you can directly include this zome in your DNA.
-//! 
+//!
 //! Read about how to include both this zome and its frontend module in your application [here](https://holochain-open-dev.github.io/profiles).
 
 use hdk::prelude::*;
 
 mod handlers;
 
-use hc_zome_profiles_types::*;
+use hc_zome_profiles_coordinator_types::*;
+use hc_zome_profiles_integrity_types::*;
 
 /// Creates the profile for the agent executing this call.
 #[hdk_extern]
@@ -27,9 +28,7 @@ pub fn update_profile(profile: Profile) -> ExternResult<Record> {
 
 /// From a search input of at least 3 characters, returns all the agents whose nickname starts with that prefix.
 #[hdk_extern]
-pub fn search_profiles(
-    search_profiles_input: SearchProfilesInput,
-) -> ExternResult<Vec<Record>> {
+pub fn search_profiles(search_profiles_input: SearchProfilesInput) -> ExternResult<Vec<Record>> {
     let agent_profiles = handlers::search_profiles(search_profiles_input.nickname_prefix)?;
 
     Ok(agent_profiles)
@@ -48,9 +47,7 @@ pub fn get_agent_profile(agent_pub_key: AgentPubKey) -> ExternResult<Option<Reco
 /// Use this function if you need to get the profile for multiple agents at the same time,
 /// as it will be more performant than doing multiple `get_agent_profile`.
 #[hdk_extern]
-pub fn get_agents_profiles(
-    agent_pub_keys: Vec<AgentPubKey>,
-) -> ExternResult<Vec<Record>> {
+pub fn get_agents_profiles(agent_pub_keys: Vec<AgentPubKey>) -> ExternResult<Vec<Record>> {
     let agent_profiles = handlers::get_agents_profiles(agent_pub_keys)?;
 
     Ok(agent_profiles)
@@ -61,8 +58,7 @@ pub fn get_agents_profiles(
 pub fn get_my_profile(_: ()) -> ExternResult<Option<Record>> {
     let agent_info = agent_info()?;
 
-    let agent_profile =
-        handlers::get_agent_profile(agent_info.agent_initial_pubkey)?;
+    let agent_profile = handlers::get_agent_profile(agent_info.agent_initial_pubkey)?;
 
     Ok(agent_profile)
 }

--- a/crates/integrity/Cargo.toml
+++ b/crates/integrity/Cargo.toml
@@ -17,5 +17,5 @@ name = "hc_zome_profiles_integrity"
 derive_more = "0"
 serde = "1"
 
-hc_zome_profiles_types = {path = "../types"}
+hc_zome_profiles_integrity_types = {path = "../types/integrity_types"}
 hdi = "0.0.14"

--- a/crates/integrity/src/lib.rs
+++ b/crates/integrity/src/lib.rs
@@ -1,24 +1,24 @@
 //! ## hc_zome_profiles
-//! 
+//!
 //! Profiles zome for any Holochain app.
-//! 
+//!
 //! If you need to manage profiles (nickname, name, avatar, age and other useful personal information)
 //! you can directly include this zome in your DNA.
-//! 
+//!
 //! Read about how to include both this zome and its frontend module in your application [here](https://holochain-open-dev.github.io/profiles).
 
 use hdi::prelude::*;
-use hc_zome_profiles_types::*;
+use hc_zome_profiles_integrity_types::*;
 
 #[hdk_entry_defs]
 #[unit_enum(UnitEntryTypes)]
 pub enum EntryTypes {
-    Profile(Profile)
+    Profile(Profile),
 }
 
 #[hdk_link_types]
 pub enum LinkTypes {
     PrefixPath,
     PathToProfile,
-    AgentToProfile
+    AgentToProfile,
 }

--- a/crates/types/README.md
+++ b/crates/types/README.md
@@ -1,7 +1,0 @@
-# hc_zome_profiles_types
-
-Types for the hc_zome_profiles zome.
-
-## Documentation
-
-See our [installation instructions and documentation](https://holochain-open-dev.github.io/profiles).

--- a/crates/types/coordinator_types/Cargo.toml
+++ b/crates/types/coordinator_types/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 authors = ["guillem.cordoba@gmail.com", "eric@harris-braun.com", "tatsuya.g.sato@yumeville.com"]
-description = "Types for the hc_zome_profiles zome"
+description = "Coordinator types for the hc_zome_profiles zome"
 documentation = "https://holochain-open-dev.github.io/profiles"
 edition = "2018"
-homepage = "https://docs.rs/hc_zome_profiles_types"
+homepage = "https://docs.rs/hc_zome_profiles_coordinator_types"
 license = "MIT"
-name = "hc_zome_profiles_types"
+name = "hc_zome_profiles_coordinator_types"
 repository = "https://github.com/holochain-open-dev/profiles"
 version = "0.0.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-name = "hc_zome_profiles_types"
+name = "hc_zome_profiles_coordinator_types"
 
 [dependencies]
 derive_more = "0"
 serde = "1"
-
-hdi = "0.0.14"

--- a/crates/types/coordinator_types/README.md
+++ b/crates/types/coordinator_types/README.md
@@ -1,0 +1,7 @@
+# hc_zome_profiles_coordinator_types
+
+Types of the coordinator zome for the hc_zome_profiles zome.
+
+## Documentationa
+
+See our [installation instructions and documentation](https://holochain-open-dev.github.io/profiles).

--- a/crates/types/coordinator_types/src/lib.rs
+++ b/crates/types/coordinator_types/src/lib.rs
@@ -1,0 +1,8 @@
+use serde::{Serialize, Deserialize};
+/// Input for the `search_profiles` zome function.
+///
+/// The nickname prefix must be of at least 3 characters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchProfilesInput {
+    pub nickname_prefix: String,
+}

--- a/crates/types/integrity_types/Cargo.toml
+++ b/crates/types/integrity_types/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["guillem.cordoba@gmail.com", "eric@harris-braun.com", "tatsuya.g.sato@yumeville.com"]
+description = "Integrity types for the hc_zome_profiles zome"
+documentation = "https://holochain-open-dev.github.io/profiles"
+edition = "2018"
+homepage = "https://docs.rs/hc_zome_profiles_integrity_types"
+license = "MIT"
+name = "hc_zome_profiles_integrity_types"
+repository = "https://github.com/holochain-open-dev/profiles"
+version = "0.0.1"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "hc_zome_profiles_integrity_types"
+
+[dependencies]
+derive_more = "0"
+serde = "1"
+
+hdi = "0.0.14"

--- a/crates/types/integrity_types/README.md
+++ b/crates/types/integrity_types/README.md
@@ -1,0 +1,7 @@
+# hc_zome_profiles_integrity_types
+
+Types of the integrity zome for the hc_zome_profiles zome.
+
+## Documentationa
+
+See our [installation instructions and documentation](https://holochain-open-dev.github.io/profiles).

--- a/crates/types/integrity_types/src/lib.rs
+++ b/crates/types/integrity_types/src/lib.rs
@@ -12,11 +12,3 @@ pub struct Profile {
     pub nickname: String,
     pub fields: BTreeMap<String, String>,
 }
-
-/// Input for the `search_profiles` zome function.
-/// 
-/// The nickname prefix must be of at least 3 characters.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SearchProfilesInput {
-    pub nickname_prefix: String,
-}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,4 +12,5 @@ hdk = {version = "0.0.142", features = ["encoding", "test_utils"]}
 holochain = {version = "0.0.150", default-features = false, features = ["test_utils"]}
 tokio = {version = "1.3", features = ["full"]}
 
-hc_zome_profiles_types = {path = "../crates/types"}
+hc_zome_profiles_coordinator_types = {path = "../crates/types/coordinator_types"}
+hc_zome_profiles_integrity_types = {path = "../crates/types/integrity_types"}

--- a/tests/tests/create_and_get.rs
+++ b/tests/tests/create_and_get.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use hc_zome_profiles_types::*;
+use hc_zome_profiles_integrity_types::*;
 use hdk::prelude::*;
 use holochain::test_utils::consistency_10s;
 use holochain::{conductor::config::ConductorConfig, sweettest::*};

--- a/tests/tests/search.rs
+++ b/tests/tests/search.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use hc_zome_profiles_types::*;
+use hc_zome_profiles_coordinator_types::*;
+use hc_zome_profiles_integrity_types::*;
 use hdk::prelude::*;
 use holochain::test_utils::consistency_10s;
 use holochain::{conductor::config::ConductorConfig, sweettest::*};


### PR DESCRIPTION
This change does not have much impact on the codebase at the moment.

However, splitting types into what is mainly used in coordinator and what is used in integrity zomes makes sure that the integrity zome does not get affected by the more frequent changes in the types defined in `coordinator_types`.

