### PR TITLE
Make get_my_profile() to query source chain instead of DHT

### DIFF
--- a/crates/coordinator/src/handlers.rs
+++ b/crates/coordinator/src/handlers.rs
@@ -49,6 +49,19 @@ pub fn update_profile(profile: Profile) -> ExternResult<Record> {
     Ok(record)
 }
 
+pub fn get_my_profile(_: ()) -> ExternResult<Option<Record>> {
+    let profile_entry_type: EntryType = UnitEntryTypes::Profile.try_into()?;
+    let filter = ChainQueryFilter::new()
+        .entry_type(profile_entry_type)
+        .include_entries(true);
+    let all_my_profiles = query(filter)?;
+
+    match all_my_profiles.last() {
+        Some(record) => Ok(Some(record.to_owned())),
+        None => Ok(None)
+    }
+}
+
 pub fn search_profiles(nickname_prefix: String) -> ExternResult<Vec<Record>> {
     if nickname_prefix.len() < 3 {
         return Err(wasm_error!(WasmErrorInner::Guest(

--- a/crates/coordinator/src/lib.rs
+++ b/crates/coordinator/src/lib.rs
@@ -56,9 +56,7 @@ pub fn get_agents_profiles(agent_pub_keys: Vec<AgentPubKey>) -> ExternResult<Vec
 /// Gets the profile for the agent calling this function, if they have created it.
 #[hdk_extern]
 pub fn get_my_profile(_: ()) -> ExternResult<Option<Record>> {
-    let agent_info = agent_info()?;
-
-    let agent_profile = handlers::get_agent_profile(agent_info.agent_initial_pubkey)?;
+    let agent_profile = handlers::get_my_profile(())?;
 
     Ok(agent_profile)
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run network 2",
     "network": "hc s clean && npm run build:happ && concurrently-repeat \"npm run start:agent\"",
     "start:agent": "cross-env HC_PORT=$(port) concurrently \"npm run playground\" \"npm run start:happ\" \"npm run start -w @holochain-open-dev/profiles\"",
-    "test": "npm run build:happ && cargo test",
+    "test": "npm run build:happ && cargo test -- --nocapture",
     "start:happ": "RUST_LOG=warn echo \"pass\" | hc s --piped generate ./workdir/happ/profiles-test.happ --run=$HC_PORT network mdns",
     "build:happ": "npm run build:dna && hc app pack workdir/happ",
     "build:dna": "npm run build:zome && hc dna pack workdir/dna",


### PR DESCRIPTION
Changes `get_my_profile()` to query from the source chain instead of going through `get_agent_profile()` which uses a `get_links()` followed by a `get_details()`.