### PR TITLE
add option to cancel edit-profile if specified as boolean property

### DIFF
--- a/ui/src/elements/edit-profile.ts
+++ b/ui/src/elements/edit-profile.ts
@@ -46,7 +46,7 @@ export class EditProfile extends ScopedElementsMixin(LitElement) {
   store!: ProfilesStore;
 
   @property({ type: Boolean })
-  allowCancel: boolean = false;
+  allowCancel = false;
 
   /** Private properties */
 

--- a/ui/src/elements/edit-profile.ts
+++ b/ui/src/elements/edit-profile.ts
@@ -45,6 +45,9 @@ export class EditProfile extends ScopedElementsMixin(LitElement) {
   @property({ type: Object })
   store!: ProfilesStore;
 
+  @property({ type: Boolean })
+  allowCancel: boolean = false;
+
   /** Private properties */
 
   @query('#nickname-field')
@@ -205,6 +208,15 @@ export class EditProfile extends ScopedElementsMixin(LitElement) {
     );
   }
 
+  fireCancel() {
+    this.dispatchEvent(
+      new CustomEvent('cancel-edit-profile', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
   renderField(fieldName: string) {
     return html`
       <mwc-textfield
@@ -255,13 +267,30 @@ export class EditProfile extends ScopedElementsMixin(LitElement) {
             this.renderField(field)
           )}
 
-          <mwc-button
-            raised
-            style="margin-top: 8px;"
-            .disabled=${!this.shouldSaveButtonBeEnabled()}
-            .label=${this.saveProfileLabel ?? msg('Save Profile')}
-            @click=${() => this.fireSaveProfile()}
-          ></mwc-button>
+
+          <div class="row" style="margin-top: 8px;">
+
+            ${this.allowCancel
+              ? html`
+              <mwc-button
+                style="flex: 1; margin-right: 6px;"
+                .label=${'Cancel'}
+                @click=${() => this.fireCancel()}
+              ></mwc-button>
+              `
+              : html``
+            }
+
+            <mwc-button
+              style="flex: 1;"
+              raised
+              .disabled=${!this.shouldSaveButtonBeEnabled()}
+              .label=${this.saveProfileLabel ?? msg('Save Profile')}
+              @click=${() => this.fireSaveProfile()}
+            ></mwc-button>
+
+          </div>
+
         </div>
       </mwc-card>
     `;

--- a/ui/src/elements/my-profile.ts
+++ b/ui/src/elements/my-profile.ts
@@ -34,6 +34,7 @@ export class MyProfile extends ScopedElementsMixin(LitElement) {
     if (this._editing)
       return html`<update-profile
         @profile-updated=${() => (this._editing = false)}
+        @cancel-edit-profile=${() => (this._editing = false)}
       ></update-profile>`;
 
     return html`

--- a/ui/src/elements/update-profile.ts
+++ b/ui/src/elements/update-profile.ts
@@ -58,6 +58,7 @@ export class UpdateProfile extends ScopedElementsMixin(LitElement) {
         <mwc-circular-progress indeterminate></mwc-circular-progress>
       </div>`,
       complete: profile => html` <edit-profile
+        allowCancel
         .profile=${profile}
         .save-profile-label=${msg('Update Profile')}
         @save-profile=${(e: CustomEvent) =>


### PR DESCRIPTION
This changes allow to cancel the edit profile process, provided that the boolean `allowCancel` property of the `<edit-profile>` component is set. In that case the component has a cancel button next to the save profile button that fires a bubbling "cancel-edit-profile" event when clicked.