### PR TITLE
fix: avoid panic when searching with unicode strings

### DIFF
--- a/crates/coordinator/src/handlers.rs
+++ b/crates/coordinator/src/handlers.rs
@@ -164,7 +164,7 @@ pub fn get_agents_profiles(agent_pub_keys: Vec<AgentPubKey>) -> ExternResult<Vec
 fn prefix_path(nickname: String) -> ExternResult<TypedPath> {
     // conver to lowercase for path for ease of search
     let lower_nickname = nickname.to_lowercase();
-    let (prefix, _) = lower_nickname.as_str().split_at(3);
+    let prefix: String = lower_nickname.chars().take(3).collect();
 
     Path::from(format!("all_profiles.{}", prefix)).typed(LinkTypes::PrefixPath)
 }

--- a/tests/tests/search.rs
+++ b/tests/tests/search.rs
@@ -82,4 +82,16 @@ async fn create_and_get() {
         .await;
 
     assert_eq!(profiles_searched.len(), 0);
+
+    let profiles_searched: Vec<Record> = conductors[1]
+    .call(
+        &bob_zome,
+        "search_profiles",
+        SearchProfilesInput {
+            nickname_prefix: "سعيدة".into(),
+        },
+    )
+    .await;
+
+    assert_eq!(profiles_searched.len(), 0);
 }


### PR DESCRIPTION
Avoids panic when searching for strings with non 3-byte unicode characters