### PR TITLE
fix(ui): Support passing _store prop into create-profile component

### DIFF
--- a/ui/src/elements/create-profile.ts
+++ b/ui/src/elements/create-profile.ts
@@ -53,6 +53,7 @@ export class CreateProfile extends ScopedElementsMixin(LitElement) {
           >
           <edit-profile
             .saveProfileLabel=${msg("Create Profile")}
+            ._store=${this._store}
             @save-profile=${(e: CustomEvent) =>
               this.createProfile(e.detail.profile)}
           ></edit-profile></div


### PR DESCRIPTION
Previously if you manually pass the `_store` prop into `<create-profile />` it would fail to render the `<edit-profile />` component within it and log an error.

This fixes that issue