### PR TITLE
agent-avatar props to disable tooltip & copy on click

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
       },
       "locked": {
         "dir": "versions/0_1",
-        "lastModified": 1679379522,
-        "narHash": "sha256-OGtX0sqS4QT5HhgLa/RdwCUHdZae5GnqbGuCqE2AAio=",
+        "lastModified": 1679768216,
+        "narHash": "sha256-FmBAlHKlL8NBxBTL8wVmsShM9jsckbs3ggnsOd/hPSk=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "988959365281e45aba63864b85ca0fc1e35eb8ac",
+        "rev": "c83ba02658a5577f99c0960e8dbf925a57466192",
         "type": "github"
       },
       "original": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16605,7 +16605,7 @@
     },
     "ui": {
       "name": "@holochain-open-dev/profiles",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@holochain-open-dev/elements": "^0.3.7",

--- a/ui/custom-elements.json
+++ b/ui/custom-elements.json
@@ -4,110 +4,6 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "locales/es-419.js",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "templates",
-          "type": {
-            "text": "object"
-          },
-          "default": "{\n      's13f20cb257e12fac': `Campo obligatorio`,\n's1d96e130c0544d92': `Aún no se ha creado ningún perfil`,\n's3798c0344c399eb7': str`Min. ${0} caracteres`,\n's39aca5bd9eed9271': `Este agente no ha creado su perfil todavía`,\n's3fa309bef44c54e9': `Al menos 3 caracteres...`,\n's6068cc1885ea6494': `No se ha encontrado ningún agente`,\n's639c68c3284a2269': `Actualizar Perfil`,\n's7892d152096ebca9': `El nombre de usuario ya existe`,\n'sb4f1dffbb6be6302': `Borrar`,\n'sbe57083b4c785878': `Crear Perfil`,\n'sc93a9aa3e5bcbf5d': `Guardar Perfil`,\n'se9f30e4492cee2cd': `Nombre de usuario`,\n'sf58564266e0fc01f': `Nombre demasiado corto`,\n'sfbf76da07548a998': `Buscar agente`,\n    }"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "templates",
-          "declaration": {
-            "name": "templates",
-            "module": "locales/es-419.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "locales/fr-fr.js",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "templates",
-          "type": {
-            "text": "object"
-          },
-          "default": "{\n      's13f20cb257e12fac': `Ce champs est obligatoire`,\n's1d96e130c0544d92': `Il n'y a pas encore de profils créés`,\n's3798c0344c399eb7': str`Min. ${0} caractères`,\n's39aca5bd9eed9271': `Cet utilisateur n'a pas encore créé de profil`,\n's3fa309bef44c54e9': `Au moins 3 caractères...`,\n's6068cc1885ea6494': `Aucun agent ne corresponds au filtre`,\n's639c68c3284a2269': `Mettre à jour Profil`,\n's7892d152096ebca9': `Le surnom est déjà pris`,\n'sb4f1dffbb6be6302': `Effacer`,\n'sbe57083b4c785878': `Créer Profil`,\n'sc93a9aa3e5bcbf5d': `Enregistrer Profil`,\n'se9f30e4492cee2cd': `Surnom`,\n'sf58564266e0fc01f': `Le surnom est trop court`,\n'sfbf76da07548a998': `Rechercher utilisateur`,\n    }"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "templates",
-          "declaration": {
-            "name": "templates",
-            "module": "locales/fr-fr.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "locales/locales.js",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "sourceLocale",
-          "default": "`en`",
-          "description": "The locale code that templates in this source code are written in."
-        },
-        {
-          "kind": "variable",
-          "name": "targetLocales",
-          "type": {
-            "text": "array"
-          },
-          "default": "[\n  `es-419`,\n  `fr-fr`,\n]",
-          "description": "The other locale codes that this application is localized into. Sorted\nlexicographically."
-        },
-        {
-          "kind": "variable",
-          "name": "allLocales",
-          "type": {
-            "text": "array"
-          },
-          "default": "[\n  `en`,\n  `es-419`,\n  `fr-fr`,\n]",
-          "description": "All valid project locale codes. Sorted lexicographically."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "sourceLocale",
-          "declaration": {
-            "name": "sourceLocale",
-            "module": "locales/locales.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "targetLocales",
-          "declaration": {
-            "name": "targetLocales",
-            "module": "locales/locales.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "allLocales",
-          "declaration": {
-            "name": "allLocales",
-            "module": "locales/locales.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/config.ts",
       "declarations": [
         {
@@ -536,6 +432,26 @@
             },
             {
               "kind": "field",
+              "name": "copyOnClick",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "description": "Enable copying of AgentPubKey to clipboard on click",
+              "attribute": "copyOnClick"
+            },
+            {
+              "kind": "field",
+              "name": "showAgentPubKeyOnHover",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "description": "Enable showing AgentPubKey in tooltip on hover",
+              "attribute": "showAgentPubKeyOnHover"
+            },
+            {
+              "kind": "field",
               "name": "store",
               "type": {
                 "text": "ProfilesStore"
@@ -596,6 +512,24 @@
               "default": "32",
               "description": "Size of the avatar image in pixels.",
               "fieldName": "size"
+            },
+            {
+              "name": "copyOnClick",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "description": "Enable copying of AgentPubKey to clipboard on click",
+              "fieldName": "copyOnClick"
+            },
+            {
+              "name": "showAgentPubKeyOnHover",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "description": "Enable showing AgentPubKey in tooltip on hover",
+              "fieldName": "showAgentPubKeyOnHover"
             },
             {
               "name": "store",
@@ -1332,6 +1266,15 @@
             },
             {
               "kind": "field",
+              "name": "defaultValue",
+              "type": {
+                "text": "AgentPubKey | undefined"
+              },
+              "description": "The default value of the field if this element is used inside a form",
+              "attribute": "defaultValue"
+            },
+            {
+              "kind": "field",
               "name": "required",
               "type": {
                 "text": "boolean"
@@ -1463,6 +1406,14 @@
               },
               "description": "The name of the field if this element is used inside a form\nRequired only if the element is used inside a form",
               "fieldName": "name"
+            },
+            {
+              "name": "defaultValue",
+              "type": {
+                "text": "AgentPubKey | undefined"
+              },
+              "description": "The default value of the field if this element is used inside a form",
+              "fieldName": "defaultValue"
             },
             {
               "name": "required",

--- a/ui/custom-elements.json
+++ b/ui/custom-elements.json
@@ -437,18 +437,18 @@
                 "text": "boolean"
               },
               "default": "true",
-              "description": "Enable copying of AgentPubKey to clipboard on click",
+              "description": "Copy AgentPubKey to clipboard on click",
               "attribute": "copyOnClick"
             },
             {
               "kind": "field",
-              "name": "showAgentPubKeyOnHover",
+              "name": "showOnHover",
               "type": {
                 "text": "boolean"
               },
               "default": "true",
-              "description": "Enable showing AgentPubKey in tooltip on hover",
-              "attribute": "showAgentPubKeyOnHover"
+              "description": "Show tooltip on hover with truncated AgentPubKey",
+              "attribute": "showOnHover"
             },
             {
               "kind": "field",
@@ -519,17 +519,17 @@
                 "text": "boolean"
               },
               "default": "true",
-              "description": "Enable copying of AgentPubKey to clipboard on click",
+              "description": "Copy AgentPubKey to clipboard on click",
               "fieldName": "copyOnClick"
             },
             {
-              "name": "showAgentPubKeyOnHover",
+              "name": "showOnHover",
               "type": {
                 "text": "boolean"
               },
               "default": "true",
-              "description": "Enable showing AgentPubKey in tooltip on hover",
-              "fieldName": "showAgentPubKeyOnHover"
+              "description": "Show tooltip on hover with truncated AgentPubKey",
+              "fieldName": "showOnHover"
             },
             {
               "name": "store",

--- a/ui/demo/index.html
+++ b/ui/demo/index.html
@@ -82,6 +82,8 @@
                     slot="badge"
                   ></div>
                 </agent-avatar>
+                <agent-avatar .agentPubKey=${this.store.client.client.myPubKey} .showAgentPubKeyOnHover=${false} .copyOnClick=${false}>
+                </agent-avatar>
               </profile-prompt>
             </profiles-context>
           `;

--- a/ui/src/elements/agent-avatar.ts
+++ b/ui/src/elements/agent-avatar.ts
@@ -45,7 +45,7 @@ export class AgentAvatar extends LitElement {
    * Show tooltip on hover with truncated AgentPubKey
    */
   @property({ type: Boolean })
-  showAgentPubKeyOnHover = true;
+  showOnHover = true;
 
   /** Dependencies */
 
@@ -121,7 +121,7 @@ export class AgentAvatar extends LitElement {
       </div>
     `;
 
-    return this.showAgentPubKeyOnHover ?
+    return this.showOnHover ?
       html`
         <sl-tooltip
           id="tooltip"

--- a/ui/src/elements/agent-avatar.ts
+++ b/ui/src/elements/agent-avatar.ts
@@ -35,6 +35,18 @@ export class AgentAvatar extends LitElement {
   @property({ type: Number })
   size = 32;
 
+  /**
+   * Copy AgentPubKey to clipboard on click
+   */
+  @property({ type: Boolean })
+  copyOnClick = true;
+
+  /**
+   * Show tooltip on hover with truncated AgentPubKey
+   */
+  @property({ type: Boolean })
+  showAgentPubKeyOnHover = true;
+
   /** Dependencies */
 
   /**
@@ -89,32 +101,41 @@ export class AgentAvatar extends LitElement {
   renderProfile(profile: Profile | undefined) {
     if (!profile || !profile.fields.avatar) return this.renderIdenticon();
 
-    return html`
-      <sl-tooltip
-        id="tooltip"
-        placement="top"
-        .content=${this.justCopiedHash
-          ? msg("Copied!")
-          : `${encodeHashToBase64(this.agentPubKey).substring(0, 6)}...`}
-        .trigger=${this.justCopiedHash ? "manual" : "hover focus"}
-        hoist
+    const contents = html`
+      <div
+        @click=${() => {
+          if (this.copyOnClick) this.copyHash();
+        }}
+        style=${styleMap({
+          position: "relative",
+          height: `${this.size}px`,
+          width: `${this.size}px`,
+        })}
       >
-        <div
-          @click=${() => this.copyHash()}
-          style=${styleMap({
-            position: "relative",
-            height: `${this.size}px`,
-            width: `${this.size}px`,
-          })}
+        <sl-avatar
+          .image=${profile.fields.avatar}
+          style="--size: ${this.size}px;"
         >
-          <sl-avatar
-            .image=${profile.fields.avatar}
-            style="--size: ${this.size}px;"
-          >
-          </sl-avatar>
-          <div class="badge"><slot name="badge"></slot></div></div
-      ></sl-tooltip>
+        </sl-avatar>
+        <div class="badge"><slot name="badge"></slot></div>
+      </div>
     `;
+
+    return this.showAgentPubKeyOnHover ?
+      html`
+        <sl-tooltip
+          id="tooltip"
+          placement="top"
+          .content=${this.justCopiedHash
+            ? msg("Copied!")
+            : `${encodeHashToBase64(this.agentPubKey).substring(0, 6)}...`}
+          .trigger=${this.justCopiedHash ? "manual" : "hover focus"}
+          hoist
+        >
+          ${contents}
+        </sl-tooltip>
+      ` : 
+      contents;
   }
 
   render() {


### PR DESCRIPTION
Adds 2 props to `<agent-avatar>`
- copyOnClick: enable/disable the copying of agentpubkey to clipboard
- showOnHover: enable/disable showing tooltip with agentpubkey on hover

Both are still enabled by default.