### PR TITLE
disable boolean props by default

### DIFF
--- a/ui/custom-elements.json
+++ b/ui/custom-elements.json
@@ -436,7 +436,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
+              "default": "false",
               "description": "Copy AgentPubKey to clipboard on click",
               "attribute": "copyOnClick"
             },
@@ -446,7 +446,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
+              "default": "false",
               "description": "Show tooltip on hover with truncated AgentPubKey",
               "attribute": "showOnHover"
             },
@@ -518,7 +518,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
+              "default": "false",
               "description": "Copy AgentPubKey to clipboard on click",
               "fieldName": "copyOnClick"
             },
@@ -527,7 +527,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
+              "default": "false",
               "description": "Show tooltip on hover with truncated AgentPubKey",
               "fieldName": "showOnHover"
             },

--- a/ui/demo/index.html
+++ b/ui/demo/index.html
@@ -76,13 +76,13 @@
                 <list-profiles></list-profiles>
                 <my-profile style="height: 800px; width: 800px;"></my-profile>
                 <search-agent required include-myself></search-agent>
-                <agent-avatar .agentPubKey=${this.store.client.client.myPubKey}>
+                <agent-avatar .agentPubKey=${this.store.client.client.myPubKey} showOnHover copyOnClick>
                   <div
                     style="background-color: lightgreen; width: 12px; height: 12px; border-radius: 50%"
                     slot="badge"
                   ></div>
                 </agent-avatar>
-                <agent-avatar .agentPubKey=${this.store.client.client.myPubKey} .showOnHover=${false} .copyOnClick=${false}>
+                <agent-avatar .agentPubKey=${this.store.client.client.myPubKey}>
                 </agent-avatar>
               </profile-prompt>
             </profiles-context>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain-open-dev/profiles",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Frontend module for the Holochain hc_zome_profiles pair zome",
   "author": "guillem.cordoba@gmail.com",
   "license": "MIT",

--- a/ui/src/elements/agent-avatar.ts
+++ b/ui/src/elements/agent-avatar.ts
@@ -71,7 +71,7 @@ export class AgentAvatar extends LitElement {
         width: `${this.size}px`,
       })}
     >
-      <holo-identicon .hash=${this.agentPubKey} .size=${this.size}>
+      <holo-identicon .hash=${this.agentPubKey} .size=${this.size} .showOnHover=${this.showOnHover} .copyOnClick=${this.copyOnClick}>
       </holo-identicon>
       <div class="badge"><slot name="badge"></slot></div>
     </div>`;

--- a/ui/src/elements/agent-avatar.ts
+++ b/ui/src/elements/agent-avatar.ts
@@ -39,13 +39,13 @@ export class AgentAvatar extends LitElement {
    * Copy AgentPubKey to clipboard on click
    */
   @property({ type: Boolean })
-  copyOnClick = true;
+  copyOnClick = false;
 
   /**
    * Show tooltip on hover with truncated AgentPubKey
    */
   @property({ type: Boolean })
-  showOnHover = true;
+  showOnHover = false;
 
   /** Dependencies */
 

--- a/ui/src/elements/list-profiles.ts
+++ b/ui/src/elements/list-profiles.ts
@@ -72,6 +72,7 @@ export class ListProfiles extends LitElement {
                 style="margin-right: 8px;"
                 .agentPubKey=${agent_pub_key}
                 @click=${() => this.fireAgentSelected(agent_pub_key)}
+                showOnHover
               >
               </agent-avatar
               ><span> ${profile.nickname}</span>

--- a/ui/src/elements/profile-detail.ts
+++ b/ui/src/elements/profile-detail.ts
@@ -85,7 +85,7 @@ export class ProfileDetail extends LitElement {
     return html`
       <div class="column">
         <div class="row" style="align-items: center">
-          <agent-avatar .agentPubKey=${this.agentPubKey}></agent-avatar>
+          <agent-avatar .agentPubKey=${this.agentPubKey} showOnHover copyOnClick></agent-avatar>
           <span style="font-size: 16px; margin-left: 8px;"
             >${profile.nickname}</span
           >


### PR DESCRIPTION
- in `<agent-avatar>` disable showOnHover and copyOnClick by default (due to custom elements constraints: https://lit.dev/docs/components/properties/#boolean-attributes). Pass into `<holo-identicon>`
- in `<list-profiles>` and `<profile-detail>` enable showOnHover and copyOnClick 
- bump version to denote changing default behavior of components

Will need to bump version of holochain-open-dev/common once that PR gets through